### PR TITLE
ci: guard argocd deploy on semantic-release output (stop tag churn/blanking)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,7 @@ jobs:
         run: |
           echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
       - name: release
+        id: semantic
         uses: cycjimmy/semantic-release-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
@@ -49,22 +50,22 @@ jobs:
             @semantic-release/exec@6.0.2
             @semantic-release/changelog@6.0.1
 
-      - uses: actions/checkout@v3
-      - name: Set env
-        run: |
-          git fetch --tags
-          export GITHUB_REF_NAME=$(git describe --tags --abbrev=0)
-          echo "RELEASE_VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
+      # Only touch argocd when semantic-release actually published a release.
+      # Without this guard the steps below ran on every push/PR, re-committing
+      # (or, with no tags, blanking) the service's tag in argocd.
       - name: checkout argocd repo
+        if: steps.semantic.outputs.new_release_published == 'true'
         uses: actions/checkout@v3
         with:
           repository: 'weeb-vip/weeb-argocd'
           token: ${{ secrets.ACCESS_TOKEN }}
           path: 'argocd'
       - name: deploy to argocd
+        if: steps.semantic.outputs.new_release_published == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           REPO_NAME: ${{ env.REPO_NAME }}
+          RELEASE_VERSION: ${{ steps.semantic.outputs.new_release_version }}
         # pull argocd repo and push to argocd
         run: |
           RELEASE_VERSION=$(echo $RELEASE_VERSION | sed 's/v//')


### PR DESCRIPTION
## Problem
The `checkout argocd repo` + `deploy to argocd` steps in `build.yaml` run **unconditionally** on every push to main *and every pull_request*. `RELEASE_VERSION` is set from `git describe` regardless of whether semantic-release cut a release, so every run re-commits the current tag into `weeb-vip/weeb-argocd` (spurious redeploys + commit noise), and blanks the tag (`tag:  # repo`) in the no-tags edge case.

## Fix
- Add `id: semantic` to the `release` step.
- Gate both argocd steps on `if: steps.semantic.outputs.new_release_published == 'true'`.
- Source the version from `steps.semantic.outputs.new_release_version` (removing the unconditional `git describe`).

Now argocd is only touched when semantic-release **actually publishes**. Verified on the anime-api template (weeb-vip/anime-api#40): on non-release runs the argocd steps show `skipped`; on a real release (v1.40.2) they run and write the tag.

## Note
`ci:` prefix, so merging this does **not** itself trigger a release — it just protects the next real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)