### PR TITLE
feat: send anime id on image-sync messages

### DIFF
--- a/internal/services/anime_processor/anime_processor.go
+++ b/internal/services/anime_processor/anime_processor.go
@@ -114,6 +114,7 @@ func (p *AnimeProcessorImpl) processPayload(ctx context.Context, data event.Even
 		}
 		imagePayload := &ImagePayload{
 			Data: ImageSchema{
+				ID:   payload.After.ID,
 				Name: title,
 				URL:  imageURL,
 				Type: DataTypeAnime,
@@ -234,6 +235,7 @@ func (p *AnimeProcessorImpl) processPayload(ctx context.Context, data event.Even
 		}
 		imagePayload := &ImagePayload{
 			Data: ImageSchema{
+				ID:   payload.After.ID,
 				Name: title,
 				URL:  imageURL,
 				Type: DataTypeAnime,

--- a/internal/services/anime_processor/types.go
+++ b/internal/services/anime_processor/types.go
@@ -73,6 +73,9 @@ type ProducerPayload struct {
 }
 
 type ImageSchema struct {
+	// ID is what image-sync keys the object by. Name is still sent so a
+	// consumer that has not picked up the id yet keeps working.
+	ID   string   `json:"id"`
 	Name string   `json:"name"`
 	URL  string   `json:"url"`
 	Type DataType `json:"type"`

--- a/internal/services/pulsar_anime_postgres_processor/processor.go
+++ b/internal/services/pulsar_anime_postgres_processor/processor.go
@@ -77,6 +77,7 @@ func (p *PulsarAnimePostgresProcessor) Process(ctx context.Context, data Payload
 		}
 		payload := &ImagePayload{
 			Data: ImageSchema{
+				ID:   data.After.ID,
 				Name: title,
 				URL:  imageURL,
 				Type: DataTypeAnime,
@@ -168,6 +169,7 @@ func (p *PulsarAnimePostgresProcessor) Process(ctx context.Context, data Payload
 		}
 		payload := &ImagePayload{
 			Data: ImageSchema{
+				ID:   data.After.ID,
 				Name: title,
 				URL:  imageURL,
 				Type: DataTypeAnime,

--- a/internal/services/pulsar_anime_postgres_processor/types.go
+++ b/internal/services/pulsar_anime_postgres_processor/types.go
@@ -72,6 +72,9 @@ type ProducerPayload struct {
 }
 
 type ImageSchema struct {
+	// ID is what image-sync keys the object by. Name is still sent so a
+	// consumer that has not picked up the id yet keeps working.
+	ID   string   `json:"id"`
 	Name string   `json:"name"`
 	URL  string   `json:"url"`
 	Type DataType `json:"type"`


### PR DESCRIPTION
image-sync now keys objects by record id rather than a title-derived slug (weeb-vip/image-sync#6). Send the id on the image message.

`name` is still sent, and image-sync falls back to it, so this can deploy in either order relative to the consumer.

Touches both the kafka (`anime_processor`) and pulsar (`pulsar_anime_postgres_processor`) paths, create and update branches in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)