### PR TITLE
feat: carry url_slug through to MySQL

### DIFF
--- a/internal/db/repositories/anime/anime_entity.go
+++ b/internal/db/repositories/anime/anime_entity.go
@@ -9,6 +9,7 @@ type Anime struct {
 	AnidbID       *string      `gorm:"column:anidbid;null" json:"anidbid"`
 	MalID         *int         `gorm:"column:mal_id;null" json:"mal_id"`
 	TheTVDBID     *string      `gorm:"column:thetvdbid;null" json:"thetvdbid"`
+	UrlSlug       *string      `gorm:"column:url_slug;null" json:"url_slug"`
 	Type          *RECORD_TYPE `gorm:"column:type;type:text;default:Anime" json:"type"`
 	TitleEn       *string      `gorm:"column:title_en;null" json:"title_en"`
 	TitleJp       *string      `gorm:"column:title_jp;null" json:"title_jp"`

--- a/internal/services/anime_processor/anime_processor.go
+++ b/internal/services/anime_processor/anime_processor.go
@@ -311,6 +311,7 @@ func (p *AnimeProcessorImpl) ParseToEntity(ctx context.Context, data Schema) (*a
 	newAnime.AnidbID = data.AnidbID
 	newAnime.MalID = data.MalID
 	newAnime.TheTVDBID = data.TheTVDBID
+	newAnime.UrlSlug = data.UrlSlug
 	newAnime.Type = record_type
 	newAnime.TitleEn = data.TitleEn
 	newAnime.TitleJp = data.TitleJp

--- a/internal/services/anime_processor/types.go
+++ b/internal/services/anime_processor/types.go
@@ -18,10 +18,13 @@ const (
 )
 
 type Schema struct {
-	ID            string  `json:"id"`
-	AnidbID       *string `json:"anidbid"`
-	MalID         *int    `json:"mal_id"`
-	TheTVDBID     *string `json:"thetvdbid"`
+	ID        string  `json:"id"`
+	AnidbID   *string `json:"anidbid"`
+	MalID     *int    `json:"mal_id"`
+	TheTVDBID *string `json:"thetvdbid"`
+	// UrlSlug is the anime's public URL segment, generated in postgres.
+	// Absent from events emitted before that column existed, hence the pointer.
+	UrlSlug       *string `json:"url_slug"`
 	TitleEn       *string `json:"title_en"`
 	TitleJp       *string `json:"title_jp"`
 	TitleRomaji   *string `json:"title_romaji"`


### PR DESCRIPTION
Second step of moving anime URLs from `/show/<uuid>` to `/anime/<slug>`.

weeb-vip/anime-api#52 added the column and the GraphQL field; this maps the CDC value onto it so the column actually gets filled.

## Changes

- `Schema` — `url_slug` on the CDC payload
- `anime` entity — `UrlSlug` on the MySQL model
- `ParseToEntity` — one line carrying it across

## Why a pointer

Events emitted before postgres has the column simply will not carry the field. A pointer means "absent" leaves the column untouched rather than blanking it, so this is safe to deploy well ahead of the postgres migration — which is the whole point of the ordering.

## What this unlocks

With this deployed, the postgres migration is the only step left. Its backfill `UPDATE` generates CDC events carrying the new value, and this writes them straight through — **no separate MySQL backfill required**.

```
1. anime-api    ✅ column + GraphQL field + lookup
2. anime-sync   ← this PR
3. postgres     add column, trigger, backfill → CDC fills MySQL for free
4. frontend     /anime/[slug] + /show/<id> 301
```

## Heads-up for step 3

That backfill touches ~29,634 rows, and this processor's update branch publishes to two other topics per event — Algolia and the image topic. So the backfill will trigger roughly 29,634 Algolia re-index operations and 29,634 image messages, the latter causing `image-sync` to re-download every poster from MyAnimeList.

weeb-vip/image-sync#11 adds an existence check so those re-downloads become cheap no-ops. Worth having that merged before the backfill runs, and worth batching the backfill regardless to keep the Algolia operation count sane.

## Verified

`go build ./...` clean, `gofmt` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)