### PR TITLE
fix: drop CDC events whose parent row is absent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.6.1
 	github.com/golang-migrate/migrate/v4 v4.17.0
 	github.com/golang/mock v1.6.0
+	github.com/jackc/pgx/v5 v5.5.5
 	github.com/jinzhu/configor v1.2.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.11.1
@@ -45,7 +46,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.5.5 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/internal/db/fkviolation.go
+++ b/internal/db/fkviolation.go
@@ -1,0 +1,40 @@
+package db
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// pgForeignKeyViolation is SQLSTATE 23503, raised when a write references a row
+// that is not there.
+const pgForeignKeyViolation = "23503"
+
+// IsForeignKeyViolation reports whether err is Postgres rejecting a write for
+// referencing a parent row that does not exist.
+//
+// It exists because CDC and foreign keys disagree about ordering. Debezium makes
+// no promise about the order of events across tables, so an episode can arrive
+// before the anime it belongs to and Postgres will refuse it. MySQL never
+// surfaced this: the constraints were declared but Vitess did not enforce them.
+//
+// A caller that treats this as a normal error retries forever. The parent will
+// not appear by retrying the child -- it arrives on its own topic, on its own
+// schedule -- so the retry occupies the consumer and the backlog stops moving.
+// That is what stalled staging for hours.
+//
+// Discarding the event is the right response for these tables. Every one of them
+// is a replica of a source of truth elsewhere; the row will be delivered again
+// the next time the source updates it, and a full snapshot replays it regardless.
+// Nothing is lost that cannot be recovered, whereas a stalled consumer loses
+// everything queued behind it.
+func IsForeignKeyViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgForeignKeyViolation
+	}
+	return false
+}

--- a/internal/services/episode_processor/episode_processor.go
+++ b/internal/services/episode_processor/episode_processor.go
@@ -44,6 +44,18 @@ func (p *EpisodeProcessorImpl) Process(ctx context.Context, data event.Event[*ka
 		}
 		err = p.Repository.Upsert(newAnime)
 		if err != nil {
+			// An episode whose anime has not arrived yet. Debezium gives no
+			// ordering guarantee across tables, so this is expected occasionally
+			// rather than exceptional. Retrying cannot fix it -- the anime arrives
+			// on its own topic, not by re-attempting the episode -- so the event is
+			// dropped and the consumer moves on. The row returns with the next
+			// update to it, or with the next snapshot.
+			if db.IsForeignKeyViolation(err) {
+				log.Warn("skipping episode whose anime is not present",
+					zap.Stringp("anime_id", newAnime.AnimeID),
+					zap.String("episode_id", newAnime.ID))
+				return data, nil
+			}
 			return data, err
 		}
 	}


### PR DESCRIPTION
A CDC event can arrive before the row it references — an episode before its anime, a link before its character. Debezium makes **no ordering guarantee across tables**, so Postgres refuses the write:

```
ERROR: insert or update on table "episodes"
  violates foreign key constraint "episodes_anime_id_fkey" (SQLSTATE 23503)
```

The processor returns that as an error, and the backoff middleware retries it. Forever.

## Why retrying cannot work

The parent is not coming on this topic. It arrives on its own, on its own schedule. So the consumer spends itself re-attempting a write that will keep failing, while everything queued behind it waits.

That is exactly what stalled staging for hours, and it is what would happen in production the moment these services are pointed at Postgres with foreign keys enforced.

## Why dropping the event is safe here

Every one of these tables is a **replica**, not a source of truth. The row is delivered again the next time the source updates it, and a snapshot replays it regardless.

Nothing is lost that cannot be recovered — whereas a blocked consumer loses everything queued behind it. That asymmetry is what makes discarding the right call for these tables specifically, and it would be the wrong call for a table that owned its data.

## Why this never came up before

MySQL declared these constraints and Vitess did not enforce them. Ordering never mattered until Postgres started checking.

The classification is narrow on purpose — `pgconn.PgError` code `23503` only. Any other failure still errors and retries as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)