### PR TITLE
fix: size the connection pool for reuse, not for opening

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -24,22 +24,23 @@ func NewDB(cfg config.DBConfig) *DB {
 		panic("failed to get database connection")
 	}
 
-	// Set maximum number of open connections
-	// This prevents too many connections to the database
-	sqlDB.SetMaxOpenConns(25)
+	// The pool is sized to be reused rather than refilled.
+	//
+	// MaxIdleConns matches MaxOpenConns deliberately: Go only retains up to
+	// MaxIdleConns, so anything opened above it is closed again the moment the
+	// query finishes -- TCP, TLS and auth paid per query rather than once.
+	//
+	// 2 because this is a Kafka consumer: it processes one message at a time,
+	// so the write concurrency is one plus a spare. The previous 25 could never
+	// be used, but counted against a database that allows 79 connections in
+	// total across roughly 36 pods.
+	sqlDB.SetMaxOpenConns(2)
+	sqlDB.SetMaxIdleConns(2)
 
-	// Set maximum number of idle connections
-	// This maintains a pool of reusable connections
-	sqlDB.SetMaxIdleConns(10)
-
-	// Set maximum lifetime of a connection
-	// Kept below any server-side idle timeout so the pool never hands out a
-	// connection the server has already closed.
-	sqlDB.SetConnMaxLifetime(5 * time.Minute)
-
-	// Set maximum idle time for a connection
-	// This helps clean up idle connections
-	sqlDB.SetConnMaxIdleTime(90 * time.Second)
+	// Long enough that connections survive quiet periods and get reused, short
+	// enough that a failover or DNS change is picked up without a restart.
+	sqlDB.SetConnMaxLifetime(30 * time.Minute)
+	sqlDB.SetConnMaxIdleTime(10 * time.Minute)
 
 	return &DB{DB: db}
 }


### PR DESCRIPTION
The pool was sized to open connections, not to reuse them.

Go retains only `MaxIdleConns`. Anything opened above that is created for one query and closed the moment it finishes — so a pool of 100 open / 10 idle was never reusing 100 connections. It held 10 and rebuilt up to 90, paying a **TCP connect, TLS handshake and Postgres auth per query**, against RDS over the internet with `sslmode=require`.

```
                  before          after
maxOpenConns      see below         n
maxIdleConns          10            n     ← matched, so the pool is actually a pool
ConnMaxLifetime    5m / 1h         30m
ConnMaxIdleTime    90s / unset     10m
```

`ConnMaxIdleTime` at 90s was working against reuse too: on light traffic, connections were reaped between requests and rebuilt on the next one, so the pool never warmed up.

## Why the numbers are small

The database is small. `db.t4g.micro` allows **79 connections in total**, and roughly **36 pods** share them. The configured ceilings summed to about 935.

- **APIs get 5** — they serve concurrent requests and benefit from parallelism
- **Consumers get 2** — they process one Kafka message at a time, so 25 could never be used, but still counted against the budget

A warm pool of 5 serves more traffic than a churning pool of 25, while claiming a fraction of the budget.

## The symptom this explains

Intermittent slow GraphQL responses with no errors. At 48/79 connections the database was not exhausted — requests were waiting on handshakes. `auth` and `user-service` were the acute case: each pod was configured for 100, so a single pod could have exhausted the database on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)